### PR TITLE
admin/pin-workflow-version

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Generate Docs
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Test with pytest
         run: |
@@ -42,7 +42,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[test]
       - name: Lint with flake8
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.8]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +32,7 @@ jobs:
           pytest --cov-report xml --cov=siglatools siglatools/tests/
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/get_next_uv_dates-manual.yml
+++ b/.github/workflows/get_next_uv_dates-manual.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   get_next_uv_dates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/get_next_uv_dates-manual.yml
+++ b/.github/workflows/get_next_uv_dates-manual.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/run-data-pipeline-manual.yml
+++ b/.github/workflows/run-data-pipeline-manual.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/run-data-pipeline-manual.yml
+++ b/.github/workflows/run-data-pipeline-manual.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run_sigla_pipeline:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/run-external-link-checker-manual.yml
+++ b/.github/workflows/run-external-link-checker-manual.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/run-external-link-checker-manual.yml
+++ b/.github/workflows/run-external-link-checker-manual.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   external_link_checker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/run-external-link-checker.yml
+++ b/.github/workflows/run-external-link-checker.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/run-external-link-checker.yml
+++ b/.github/workflows/run-external-link-checker.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   external_link_checker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/run-qa-test-manual.yml
+++ b/.github/workflows/run-qa-test-manual.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run_qa_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/run-qa-test-manual.yml
+++ b/.github/workflows/run-qa-test-manual.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/run-subset-pipeline-manual.yml
+++ b/.github/workflows/run-subset-pipeline-manual.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   load_spreadsheets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/run-subset-pipeline-manual.yml
+++ b/.github/workflows/run-subset-pipeline-manual.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Decrypt Google API secret
         run: ./.github/scripts/decrypt_google_api_secret.sh

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -4,11 +4,10 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.8]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +24,7 @@ jobs:
           pytest siglatools/tests/
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[all]
       - name: Test with pytest
         run: |
@@ -34,7 +34,7 @@ jobs:
           python-version: 3.8
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0
           pip install .[test]
       - name: Lint with flake8
         run: |

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ requirements = [
     "google-api-python-client==2.54.0",
     "google-auth==2.9.1",
     "pymongo[tls]==4.2.0",
-    "dnspython==2.6.1",
+    "dnspython==2.2.1",
     "dask[bag]==2022.7.1",
     "distributed==2022.7.1",
-    "prefect==2.16.5",
+    "prefect==1.2.4",
     "requests==2.28.1",
     "urllib3==1.26.11",
 ]


### PR DESCRIPTION
See #67 for reasons for change. 

Pin the workflows to always use ubutu-22.04.

Pin pip, setuptools and wheel with versions compatible with prefect 1.2.4.
```pip install --upgrade pip==24.0 setuptools==70.0.0 wheel==0.43.0```
